### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ It gives you the possibility to update the current value by calling:
 - (void)updateToCurrentValue:(NSInteger)currentValue animated:(BOOL)animated;
 ```
 
-##Installation Cocoapods
+##Installation CocoaPods
 
 Add this in your Podfile
 ```
 pod 'EAColourfulProgressView', '~> 0.1.0'
 ```
 
-**Note:** In order to have Live Rendering working properly, please install the `Cocoapods 0.36.0.beta.1` or newer, and make sure `use_frameworks!` is added to your `Podfile`. More details [here](http://stackoverflow.com/a/28108248/764822).
+**Note:** In order to have Live Rendering working properly, please install the `CocoaPods 0.36.0.beta.1` or newer, and make sure `use_frameworks!` is added to your `Podfile`. More details [here](http://stackoverflow.com/a/28108248/764822).
 
 ##Usage
 Set the `Custom Class` of a `UIView` to `EAColourfulProgressView` in Interface Builder, customize the available variables and see them being live rendered ;)


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
